### PR TITLE
use GH url for remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    shikokuchuo/nanonext (>= 1.2.1.9002)
+    nanonext (>= 1.2.1.9002)
 Enhances: 
     parallel,
     promises
@@ -35,3 +35,4 @@ Suggests:
     litedown
 VignetteBuilder: litedown
 RoxygenNote: 7.3.2
+Remotes: shikokuchuo/nanonext

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.2.1.9002)
+    shikokuchuo/nanonext (>= 1.2.1.9002)
 Enhances: 
     parallel,
     promises


### PR DESCRIPTION
The remotes or pak packages can't install the GH version of mirai since the remote for doesn't include the repo name: 

```
> pak::pak("shikokuchuo/mirai", ask = FALSE)
✔ Loading metadata database ... done                          
Error:                                                                     
! error in pak subprocess
Caused by error: 
! Could not solve package dependencies:
* shikokuchuo/mirai: Can't install dependency nanonext (>= 1.2.1.9002) 
```

This PR adds that to `remotes:`. 