### PR TITLE
Simplify mirai_map() collection syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mirai
 Type: Package
 Title: Minimalist Async Evaluation Framework for R
-Version: 1.2.0.9010
+Version: 1.2.0.9011
 Description: Designed for simplicity, a 'mirai' evaluates an R expression
     asynchronously in a parallel process, locally or distributed over the
     network, with the result automatically available upon completion. Modern

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
-# mirai 1.2.0.9010 (development)
+# mirai 1.2.0.9011 (development)
 
-* `everywhere()` now errors if the specified compute profile is not yet set up, rather than fail silently.
+* `mirai_map()` behavioural changes:
+  - Combining multiple collection options becomes easier, allowing for instance `x[.stop, .progress]`.
+  - Adds `mirai_map()[.progress_cli]` as an alternative progress indicator, using the 'cli' package to show % complete and ETA.
 * Fixes flatmap with `mirai_map()[.flat]` assigning a variable 'typ' to the calling environment.
-* Adds `mirai_map()[.progress_cli]` as an alternative progress indicator, using the 'cli' package to show % complete and ETA.
+* `everywhere()` now errors if the specified compute profile is not yet set up, rather than fail silently.
 * Internal performance enhancements.
 * Requires `nanonext` >= [1.2.1.9015].
 

--- a/R/map.R
+++ b/R/map.R
@@ -64,8 +64,8 @@
 #'     already in progress continue to completion, although their results are
 #'     not collected.
 #'
-#'     The options above may be combined in a vector, for example: \cr
-#'     \code{x[c(.stop, .progress)]} applies early stopping together with a
+#'     The options above may be combined in the manner of: \cr
+#'     \code{x[.stop, .progress]} which applies early stopping together with a
 #'     progress indicator.
 #'
 #' @details Sends each application of function \code{.f} on an element of
@@ -130,7 +130,7 @@
 #' # generates warning as daemons not set
 #' # stops early when second element returns an error
 #' tryCatch(
-#'   mirai_map(list(list(1, "a", 3), 3:1), sum)[.stop],
+#'   mirai_map(list(list(1, "a", 3), 3:1), sum)[.stop, .flat],
 #'   error = identity
 #' )
 #'
@@ -219,10 +219,11 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "
 
 #' @export
 #'
-`[.mirai_map` <- function(x, expr) {
+`[.mirai_map` <- function(x, ...) {
 
-  missing(expr) && return(collect_aio_(x))
+  missing(..1) && return(collect_aio_(x))
 
+  expr <- if (...length() > 1L) do.call(expression, list(...)) else ..1
   xlen <- length(x)
   i <- 0L
   typ <- xi <- NULL

--- a/man/dot-flat.Rd
+++ b/man/dot-flat.Rd
@@ -52,8 +52,8 @@ Expressions to insert into the \code{[]} method for \sQuote{mirai_map}
     already in progress continue to completion, although their results are
     not collected.
 
-    The options above may be combined in a vector, for example: \cr
-    \code{x[c(.stop, .progress)]} applies early stopping together with a
+    The options above may be combined in the manner of: \cr
+    \code{x[.stop, .progress]} which applies early stopping together with a
     progress indicator.
 }
 

--- a/man/mirai_map.Rd
+++ b/man/mirai_map.Rd
@@ -77,8 +77,8 @@ Sends each application of function \code{.f} on an element of
     already in progress continue to completion, although their results are
     not collected.
 
-    The options above may be combined in a vector, for example: \cr
-    \code{x[c(.stop, .progress)]} applies early stopping together with a
+    The options above may be combined in the manner of: \cr
+    \code{x[.stop, .progress]} which applies early stopping together with a
     progress indicator.
 }
 
@@ -130,7 +130,7 @@ daemons(0)
 # generates warning as daemons not set
 # stops early when second element returns an error
 tryCatch(
-  mirai_map(list(list(1, "a", 3), 3:1), sum)[.stop],
+  mirai_map(list(list(1, "a", 3), 3:1), sum)[.stop, .flat],
   error = identity
 )
 


### PR DESCRIPTION
To use:

```r
daemons(4)
mirai_map(1:4, Sys.sleep)[.progress, .sleep]
daemons(0)
```
rather than the clunkier:

```r
daemons(4)
mirai_map(1:4, Sys.sleep)[c(.progress, .sleep)]
daemons(0)
```