### PR TITLE
Allow control over whether to reset daemons settings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mirai
 Type: Package
 Title: Minimalist Async Evaluation Framework for R
-Version: 1.2.0.9015
+Version: 1.2.0.9016
 Description: Designed for simplicity, a 'mirai' evaluates an R expression
     asynchronously in a parallel process, locally or distributed over the
     network, with the result automatically available upon completion. Modern

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # mirai 1.2.0.9015 (development)
 
 * `daemons(dispatcher = NA)` now provides access to threaded dispatcher (experimental). This implements dispatcher using a thread rather than an external process and is faster and more efficient.
+* `daemons()` gains argument 'force' to allow control over whether calls to `daemons()` resets previous settings for the same compute profile.
 * `mirai_map()` behavioural changes:
   - Combining multiple collection options becomes easier, allowing for instance `x[.stop, .progress]`.
   - Adds `mirai_map()[.progress_cli]` as an alternative progress indicator, using the 'cli' package to show % complete and ETA.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# mirai 1.2.0.9015 (development)
+# mirai 1.2.0.9016 (development)
 
 * `daemons(dispatcher = NA)` now provides access to threaded dispatcher (experimental). This implements dispatcher using a thread rather than an external process and is faster and more efficient.
 * `daemons()` behavioural changes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 # mirai 1.2.0.9015 (development)
 
 * `daemons(dispatcher = NA)` now provides access to threaded dispatcher (experimental). This implements dispatcher using a thread rather than an external process and is faster and more efficient.
-* `daemons()` gains argument 'force' to allow control over whether calls to `daemons()` resets previous settings for the same compute profile.
+* `daemons()` behavioural changes:
+  - Return value is now always an integer value - either the number of daemons set if using dispatcher, or the number of daemons launched locally (zero if using a remote launcher).
+  - Gains argument 'force' to control whether calls to `daemons()` resets previous settings for the same compute profile.
 * `mirai_map()` behavioural changes:
   - Combining multiple collection options becomes easier, allowing for instance `x[.stop, .progress]`.
   - Adds `mirai_map()[.progress_cli]` as an alternative progress indicator, using the 'cli' package to show % complete and ETA.

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -68,13 +68,9 @@
 #'     vector comprising [i] the TLS certificate (optionally certificate chain)
 #'     and [ii] the associated private key.
 #'
-#' @return Depending on the arguments supplied:
-#'
-#'     \itemize{
-#'     \item using dispatcher: integer number of daemons set.
-#'     \item or else launching local daemons: integer number of daemons launched.
-#'     \item otherwise: the character host URL.
-#'     }
+#' @return If using dispatcher, the integer number of daemons set, or else the
+#'     integer number of daemons launched locally (zero if using a remote
+#'     launcher).
 #'
 #' @details Use \code{daemons(0)} to reset daemon connections:
 #'     \itemize{
@@ -386,7 +382,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ..., force 
   }
 
   is.null(envir) && return(0L)
-  `class<-`(if (envir[["n"]]) envir[["n"]] else envir[["urls"]], c("miraiDaemons", .compute))
+  `class<-`(envir[["n"]], c("miraiDaemons", .compute))
 
 }
 

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -48,6 +48,10 @@
 #'     dispatcher and \sQuote{asyncdial}, \sQuote{autoexit}, \sQuote{cleanup},
 #'     \sQuote{output}, \sQuote{maxtasks}, \sQuote{idletime}, \sQuote{walltime}
 #'     and \sQuote{timerstart} at daemon.
+#' @param force [default TRUE] logical value whether to always reset and apply
+#'     new daemons settings, even if the compute profile is already set up. If
+#'     FALSE, to apply new daemons settings requires daemons to be explicitly
+#'     reset first using \code{daemons(0)}.
 #' @param seed [default NULL] (optional) supply a random seed (single value,
 #'     interpreted as an integer). This is used to inititalise the L'Ecuyer-CMRG
 #'     RNG streams sent to each daemon. Note that reproducible results can be
@@ -80,8 +84,8 @@
 #'     \item Any unresolved \sQuote{mirai} will return an \sQuote{errorValue} 19
 #'     (Connection reset) after a reset.
 #'     \item Calling \code{daemons} with revised (or even the same) settings for
-#'     the same compute profile implicitly resets daemons before applying the
-#'     new settings.
+#'     the same compute profile resets daemons before applying the new settings
+#'     if \code{force = TRUE}.
 #'     }
 #'
 #'     If the host session ends, all connected dispatcher and daemon processes
@@ -284,7 +288,7 @@
 #'
 #' @export
 #'
-daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
+daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ..., force = TRUE,
                     seed = NULL, tls = NULL, pass = NULL, .compute = "default") {
 
   missing(n) && missing(url) && return(status(.compute))
@@ -373,7 +377,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
         `[[<-`(envir, "urls", urld)
       }
       `[[<-`(.., .compute, `[[<-`(`[[<-`(envir, "sock", sock), "n", n))
-    } else {
+    } else if (force) {
       daemons(n = 0L, .compute = .compute)
       return(daemons(n = n, url = url, remote = remote, dispatcher = dispatcher, ...,
                      seed = seed, tls = tls, pass = pass, .compute = .compute))

--- a/man/daemons.Rd
+++ b/man/daemons.Rd
@@ -74,13 +74,9 @@ provided through a function that returns this value, rather than directly.}
 to use (each compute profile has its own independent set of daemons).}
 }
 \value{
-Depending on the arguments supplied:
-
-    \itemize{
-    \item using dispatcher: integer number of daemons set.
-    \item or else launching local daemons: integer number of daemons launched.
-    \item otherwise: the character host URL.
-    }
+If using dispatcher, the integer number of daemons set, or else the
+    integer number of daemons launched locally (zero if using a remote
+    launcher).
 }
 \description{
 Set \sQuote{daemons} or persistent background processes to receive

--- a/man/daemons.Rd
+++ b/man/daemons.Rd
@@ -10,6 +10,7 @@ daemons(
   remote = NULL,
   dispatcher = TRUE,
   ...,
+  force = TRUE,
   seed = NULL,
   tls = NULL,
   pass = NULL,
@@ -42,6 +43,11 @@ if launching daemons. These include \sQuote{retry} and \sQuote{token} at
 dispatcher and \sQuote{asyncdial}, \sQuote{autoexit}, \sQuote{cleanup},
 \sQuote{output}, \sQuote{maxtasks}, \sQuote{idletime}, \sQuote{walltime}
 and \sQuote{timerstart} at daemon.}
+
+\item{force}{[default TRUE] logical value whether to always reset and apply
+new daemons settings, even if the compute profile is already set up. If
+FALSE, to apply new daemons settings requires daemons to be explicitly
+reset first using \code{daemons(0)}.}
 
 \item{seed}{[default NULL] (optional) supply a random seed (single value,
 interpreted as an integer). This is used to inititalise the L'Ecuyer-CMRG
@@ -93,8 +99,8 @@ Use \code{daemons(0)} to reset daemon connections:
     \item Any unresolved \sQuote{mirai} will return an \sQuote{errorValue} 19
     (Connection reset) after a reset.
     \item Calling \code{daemons} with revised (or even the same) settings for
-    the same compute profile implicitly resets daemons before applying the
-    new settings.
+    the same compute profile resets daemons before applying the new settings
+    if \code{force = TRUE}.
     }
 
     If the host session ends, all connected dispatcher and daemon processes

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -104,15 +104,17 @@ connection && {
 # additional daemons tests
 connection && .Platform[["OS.type"]] != "windows" && {
   Sys.sleep(1L)
-  nanotest(daemons(url = value <- local_url(), dispatcher = FALSE) == value)
-  nanotesti(status()$daemons, nextget("urls"))
+  nanotestz(daemons(url = value <- local_url(), dispatcher = FALSE))
+  nanotesti(status()$daemons, value)
+  nanotesti(nextget("urls"), value)
   nanotestz(daemons(0L))
   Sys.sleep(1L)
   nanotest(is.character(launch_remote("ws://[::1]:5555", remote = remote_config(command = "echo", args = list(c("Test out:", ".", ">/dev/null")), rscript = "/usr/lib/R/bin/Rscript"))))
   nanotest(is.character(launch_remote("tcp://localhost:5555", remote = ssh_config(remotes = c("ssh://remotehost", "ssh://remotenode"), tunnel = TRUE, command = "echo"))))
   nanotestn(launch_local(local_url(), .compute = "test"))
   Sys.sleep(1L)
-  nanotest(daemons(n = 2L, url = value <- "ws://:0", dispatcher = FALSE, remote = remote_config(quote = TRUE)) != value)
+  nanotestz(daemons(n = 2L, url = value <- "ws://:0", dispatcher = FALSE, remote = remote_config(quote = TRUE)))
+  nanotest(status()$daemons != value)
   nanotestz(daemons(0L))
   Sys.sleep(1L)
   m <- with(daemons(1, dispatcher = FALSE, .compute = "ml"), {


### PR DESCRIPTION
Adds argument 'force'.

Defaults to TRUE so no change in existing behaviour, although this was only brought in fairly recently in mirai 1.1.0.

The previous behaviour had the advantage of "being explicit", but introduced a behavioural dependency on past actions which could be confusing for interactive use.

Adding this setting improves behaviour for programmatic use, where the presumption is to set `force = FALSE`.

For #137, packages using `mirai` could then reliably use this without overriding any settings explicitly specified by users outside of their packages. 