### PR TITLE
Do not unload namespaces in package cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mirai
 Type: Package
 Title: Minimalist Async Evaluation Framework for R
-Version: 1.3.0.9000
+Version: 1.3.0.9001
 Description: Designed for simplicity, a 'mirai' evaluates an R expression
     asynchronously in a parallel process, locally or distributed over the
     network, with the result automatically available upon completion. Modern

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# mirai 1.3.0.9000 (development)
+# mirai 1.3.0.9001 (development)
 
 #### Updates
 
+* Cleanup of packages only detaches them from the search path and does not attempt to unload them, as it is not always safe to do so (thanks @D3SL, #166).
 * `serialization()` deprecated in mirai 1.2.0 is now removed.
 
 # mirai 1.3.0

--- a/R/daemon.R
+++ b/R/daemon.R
@@ -227,7 +227,7 @@ parse_cleanup <- function(cleanup)
 
 perform_cleanup <- function(cleanup) {
   if (cleanup[1L]) rm(list = (vars <- names(.GlobalEnv))[!vars %in% .[["vars"]]], envir = .GlobalEnv)
-  if (cleanup[2L]) lapply((new <- search())[!new %in% .[["se"]]], detach, unload = TRUE, character.only = TRUE)
+  if (cleanup[2L]) lapply((new <- search())[!new %in% .[["se"]]], detach, character.only = TRUE)
   if (cleanup[3L]) options(.[["op"]])
   if (cleanup[4L]) gc(verbose = FALSE)
 }


### PR DESCRIPTION
Fixes #166.

@wlandau this is my proposed fix. Please let me know if you can think of any corner cases - I can't think how this change would be problematic. Thanks!