### PR TITLE
Add 'options' argument for collect_mirai()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   + The cli package is used, if installed, for richer progress bars and error messages.
   + `[.progress_cli]` is no longer a separate option.
   + `[.stop]` now reports the index number that errored.
-* `collect_mirai()` now takes an 'options' argument, to which collection options should be supplied as a character vector. This avoids non-standard evaluation in this function.
+* `collect_mirai()` replaces '...' with an 'options' argument, to which collection options should be supplied as a character vector. This avoids non-standard evaluation in this function.
 * `daemon()` now returns an integer exit code to indicate the reason for termination.
 * Adds `nextcode()` to provide a human-readable translation of the exit codes returned by `daemon()`.
 * `everywhere()` now returns a list of at least one mirai regardless of the number of actual connections.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   + The cli package is used, if installed, for richer progress bars and error messages.
   + `[.progress_cli]` is no longer a separate option.
   + `[.stop]` now reports the index number that errored.
+* `collect_mirai()` now takes an 'options' argument, to which collection options should be supplied as a character vector. This avoids non-standard evaluation in this function.
 * `daemon()` now returns an integer exit code to indicate the reason for termination.
 * Adds `nextcode()` to provide a human-readable translation of the exit codes returned by `daemon()`.
 * `everywhere()` now returns a list of at least one mirai regardless of the number of actual connections.

--- a/R/map.R
+++ b/R/map.R
@@ -213,11 +213,7 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "
 
   missing(..1) && return(collect_aio_(x))
 
-  if (is.null(.[[".flat"]])) {
-    cli <- requireNamespace("cli", quietly = TRUE)
-    `[[<-`(`[[<-`(`[[<-`(., ".flat", if (cli) flat_cli else .flat),".progress", if (cli) progress_cli else .progress), ".stop", if (cli) stop_cli else .stop)
-  }
-
+  ensure_cli_initialized()
   dots <- eval(`[[<-`(substitute(alist(...)), 1L, quote(list)), envir = .)
   map(x, dots)
 
@@ -272,6 +268,12 @@ print.mirai_map <- function(x, ...) {
 )
 
 # internals --------------------------------------------------------------------
+
+ensure_cli_initialized <- function()
+  if (is.null(.[[".flat"]])) {
+    cli <- requireNamespace("cli", quietly = TRUE)
+    `[[<-`(`[[<-`(`[[<-`(., ".flat", if (cli) flat_cli else .flat), ".progress", if (cli) progress_cli else .progress), ".stop", if (cli) stop_cli else .stop)
+  }
 
 map <- function(x, dots) {
 

--- a/R/map.R
+++ b/R/map.R
@@ -212,7 +212,14 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "
 `[.mirai_map` <- function(x, ...) {
 
   missing(..1) && return(collect_aio_(x))
-  map(x, ...)
+
+  if (is.null(.[[".flat"]])) {
+    cli <- requireNamespace("cli", quietly = TRUE)
+    `[[<-`(`[[<-`(`[[<-`(., ".flat", if (cli) flat_cli else .flat),".progress", if (cli) progress_cli else .progress), ".stop", if (cli) stop_cli else .stop)
+  }
+
+  dots <- eval(`[[<-`(substitute(alist(...)), 1L, quote(list)), envir = .)
+  map(x, dots)
 
 }
 
@@ -266,14 +273,8 @@ print.mirai_map <- function(x, ...) {
 
 # internals --------------------------------------------------------------------
 
-map <- function(x, ...) {
+map <- function(x, dots) {
 
-  if (is.null(.[[".flat"]])) {
-    cli <- requireNamespace("cli", quietly = TRUE)
-    `[[<-`(`[[<-`(`[[<-`(., ".flat", if (cli) flat_cli else .flat),".progress", if (cli) progress_cli else .progress), ".stop", if (cli) stop_cli else .stop)
-  }
-
-  dots <- eval(`[[<-`(substitute(alist(...)), 1L, quote(list)), envir = .)
   expr <- if (length(dots) > 1L) do.call(expression, dots) else dots[[1L]]
   xlen <- length(x)
   i <- 0L

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -352,8 +352,10 @@ call_mirai_ <- call_aio_
 #' \code{x}, and is equivalent to \code{collect_mirai(x)}.
 #'
 #' @inheritParams call_mirai
-#' @param ... (if \sQuote{x} is a list of mirai) any of the collection options
-#'   for \code{\link{mirai_map}}, such as \code{.flat}.
+#' @param options (if \sQuote{x} is a list of mirai) a character vector
+#'   comprising any combination of collection options for
+#'   \code{\link{mirai_map}}, such as \code{".flat"} or
+#'   \code{c(".progress", ".stop")}.
 #'
 #' @return An object (the return value of the \sQuote{mirai}), or a list of such
 #'   objects (the same length as \sQuote{x}, preserving names).
@@ -377,17 +379,24 @@ call_mirai_ <- call_aio_
 #' # mirai_map with collection options
 #' daemons(1, dispatcher = FALSE)
 #' m <- mirai_map(1:3, rnorm)
-#' collect_mirai(m, .flat, .progress)
+#' collect_mirai(m, c(".flat", ".progress"))
 #' daemons(0)
 #'
 #' }
 #'
 #' @export
 #'
-collect_mirai <- function(x, ...) {
+collect_mirai <- function(x, options = NULL) {
 
-  is.list(x) && ...length() && return(map(x, ...))
-  collect_aio_(x)
+  is.list(x) && length(options) || return(collect_aio_(x))
+
+  if (is.null(.[[".flat"]])) {
+    cli <- requireNamespace("cli", quietly = TRUE)
+    `[[<-`(`[[<-`(`[[<-`(., ".flat", if (cli) flat_cli else .flat),".progress", if (cli) progress_cli else .progress), ".stop", if (cli) stop_cli else .stop)
+  }
+
+  dots <- mget(options, envir = .)
+  map(x, dots)
 
 }
 

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -74,8 +74,8 @@
 #' part of \sQuote{.expr}.
 #'
 #' For evaluation to occur \emph{as if} in your global environment, supply
-#' objects to \sQuote{...} rather than \sQuote{.args}. This is important when
-#' supplying free variables defined in function bodies, as scoping rules may
+#' objects to \sQuote{...} rather than \sQuote{.args}, e.g. for free variables
+#' or helper functions defined in function bodies, as scoping rules may
 #' otherwise prevent them from being found.
 #'
 #' @section Timeouts:

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -390,11 +390,7 @@ collect_mirai <- function(x, options = NULL) {
 
   is.list(x) && length(options) || return(collect_aio_(x))
 
-  if (is.null(.[[".flat"]])) {
-    cli <- requireNamespace("cli", quietly = TRUE)
-    `[[<-`(`[[<-`(`[[<-`(., ".flat", if (cli) flat_cli else .flat),".progress", if (cli) progress_cli else .progress), ".stop", if (cli) stop_cli else .stop)
-  }
-
+  ensure_cli_initialized()
   dots <- mget(options, envir = .)
   map(x, dots)
 

--- a/man/collect_mirai.Rd
+++ b/man/collect_mirai.Rd
@@ -4,13 +4,15 @@
 \alias{collect_mirai}
 \title{mirai (Collect Value)}
 \usage{
-collect_mirai(x, ...)
+collect_mirai(x, options)
 }
 \arguments{
 \item{x}{a \sQuote{mirai} object, or list of \sQuote{mirai} objects.}
 
-\item{...}{(if \sQuote{x} is a list of mirai) any of the collection options
-for \code{\link{mirai_map}}, such as \code{.flat}.}
+\item{options}{(if \sQuote{x} is a list of mirai) a character vector
+comprising any combination of collection options for
+\code{\link{mirai_map}}, such as \code{".flat"} or
+\code{c(".progress", ".stop")}.}
 }
 \value{
 An object (the return value of the \sQuote{mirai}), or a list of such
@@ -71,7 +73,7 @@ m[]
 # mirai_map with collection options
 daemons(1, dispatcher = FALSE)
 m <- mirai_map(1:3, rnorm)
-collect_mirai(m, .flat, .progress)
+collect_mirai(m, c(".flat", ".progress"))
 daemons(0)
 
 }

--- a/man/collect_mirai.Rd
+++ b/man/collect_mirai.Rd
@@ -4,7 +4,7 @@
 \alias{collect_mirai}
 \title{mirai (Collect Value)}
 \usage{
-collect_mirai(x, options)
+collect_mirai(x, options = NULL)
 }
 \arguments{
 \item{x}{a \sQuote{mirai} object, or list of \sQuote{mirai} objects.}

--- a/man/everywhere.Rd
+++ b/man/everywhere.Rd
@@ -59,8 +59,8 @@ functions. Functions from a package should use namespaced calls such as
 part of \sQuote{.expr}.
 
 For evaluation to occur \emph{as if} in your global environment, supply
-objects to \sQuote{...} rather than \sQuote{.args}. This is important when
-supplying free variables defined in function bodies, as scoping rules may
+objects to \sQuote{...} rather than \sQuote{.args}, e.g. for free variables
+or helper functions defined in function bodies, as scoping rules may
 otherwise prevent them from being found.
 }
 

--- a/man/mirai.Rd
+++ b/man/mirai.Rd
@@ -71,8 +71,8 @@ functions. Functions from a package should use namespaced calls such as
 part of \sQuote{.expr}.
 
 For evaluation to occur \emph{as if} in your global environment, supply
-objects to \sQuote{...} rather than \sQuote{.args}. This is important when
-supplying free variables defined in function bodies, as scoping rules may
+objects to \sQuote{...} rather than \sQuote{.args}, e.g. for free variables
+or helper functions defined in function bodies, as scoping rules may
 otherwise prevent them from being found.
 }
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -249,7 +249,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   q <- quote({ list2env(list(b = 2), envir = .GlobalEnv); 0L})
   mm <- everywhere(q)
   test_type("list", mm)
-  test_zero(collect_mirai(mm, .flat))
+  test_zero(collect_mirai(mm, ".flat"))
   m <- mirai(b, .timeout = 1000)
   if (!is_error_value(m[])) test_equal(m[], 2L)
   test_null(saisei(1))


### PR DESCRIPTION
Removes NSE from `collect_mirai()` to allow easier programmatic use.