### PR TITLE
Fixes mirai_map() evaluates language objects too early

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mirai
 Type: Package
 Title: Minimalist Async Evaluation Framework for R
-Version: 2.0.1.9001
+Version: 2.0.1.9002
 Description: Designed for simplicity, a 'mirai' evaluates an R expression
     asynchronously in a parallel process, locally or distributed over the
     network, with the result automatically available upon completion. Modern

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
-# mirai 2.0.1.9001 (development)
+# mirai 2.0.1.9002 (development)
 
 #### Updates
 
 * `mirai_map()` multiple map on a dataframe or matrix now correctly preserves the row names of the input as the names of the output.
+* Fixes language objects passed to `mirai_map()` being evaluated before the map function is applied (#194).
 
 # mirai 2.0.1
 

--- a/R/map.R
+++ b/R/map.R
@@ -181,7 +181,7 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "
       lapply(
         seq_len(xilen),
         function(i) mirai(
-          .expr = do.call(.f, c(.x, .args)),
+          .expr = do.call(.f, c(.x, .args), quote = TRUE),
           ...,
           .args = list(.f = .f, .x = if (is_matrix) as.list(.x[i, ]) else lapply(.x, .subset2, i), .args = .args),
           .compute = .compute
@@ -194,7 +194,7 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "
       lapply(
         .x,
         function(x) mirai(
-          .expr = do.call(.f, c(list(.x), .args)),
+          .expr = do.call(.f, c(list(.x), .args), quote = TRUE),
           ...,
           .args = list(.f = .f, .x = x, .args = .args),
           .compute = .compute

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -137,6 +137,7 @@ connection && .Platform[["OS.type"]] != "windows" && {
   test_true(all(mres == 7L))
   test_null(names(mres))
   test_true(all(mirai_map(list(c(a = 1, b = 1, c = 1), 3), sum)[.flat] == 3))
+  test_type("language", mirai_map(list(quote(1+2)), identity)[][[1]])
   test_zero(daemons(0L))
 }
 # parallel cluster tests


### PR DESCRIPTION
Closes #194.

Just requires `quote = TRUE` for the `do.call()`.

Includes a regression test.