### PR TITLE
UI consistency wrt interruptibility

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,8 @@
 
 #### Updates
 
-* `call_mirai()` has been made user-interruptible, which is now consistent with all other functions in the package.
+* `call_mirai()` is now user-interruptible, consistent with all other functions in the package.
   + `call_mirai_()` is hence redundant and now deprecated.
-  + Should there be a need for blocking behaviour, see `nanonext::call_aio()`.
   
 # mirai 2.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # mirai (development version)
 
+#### Updates
+
+* `call_mirai()` has been made user-interruptible, which is now consistent with all other functions in the package.
+  + `call_mirai_()` is hence redundant and now deprecated.
+  + Should there be a need for blocking behaviour, see `nanonext::call_aio()`.
+  
 # mirai 2.1.0
 
 #### Behavioural Changes

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -271,9 +271,8 @@ everywhere <- function(.expr, ..., .args = list(), .compute = "default") {
 
 #' mirai (Call Value)
 #'
-#' \code{call_mirai} waits for the \sQuote{mirai} to resolve if still in
-#' progress, storing the value at \code{$data}, and returns the \sQuote{mirai}
-#' object.
+#' Waits for the \sQuote{mirai} to resolve if still in progress, storing the
+#' value at \code{$data}, and returns the \sQuote{mirai} object.
 #'
 #' Accepts a list of \sQuote{mirai} objects, such as that returned by
 #' \code{\link{mirai_map}} as well as individual \sQuote{mirai}.

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -275,14 +275,14 @@ everywhere <- function(.expr, ..., .args = list(), .compute = "default") {
 #' progress, storing the value at \code{$data}, and returns the \sQuote{mirai}
 #' object.
 #'
-#' Both functions accept a list of \sQuote{mirai} objects, such as that returned
-#' by \code{\link{mirai_map}} as well as individual \sQuote{mirai}.
+#' Accepts a list of \sQuote{mirai} objects, such as that returned by
+#' \code{\link{mirai_map}} as well as individual \sQuote{mirai}.
 #'
-#' They will wait for the asynchronous operation(s) to complete if still in
-#' progress (blocking).
+#' Waits for the asynchronous operation(s) to complete if still in progress,
+#' blocking but user-interruptible.
 #'
 #' \code{x[]} may also be used to wait for and return the value of a mirai
-#' \code{x}, and is the equivalent of \code{call_mirai_(x)$data}.
+#' \code{x}, and is the equivalent of \code{call_mirai(x)$data}.
 #'
 #' @param x a \sQuote{mirai} object, or list of \sQuote{mirai} objects.
 #'
@@ -300,6 +300,10 @@ everywhere <- function(.expr, ..., .args = list(), .compute = "default") {
 #' flow statements such as \code{while} or \code{if}.
 #'
 #' @inheritSection mirai Errors
+#'
+#' @note
+#' \code{call_mirai_} is deprecated and exported for historical compatibility
+#' only. It will be removed in a future package version.
 #'
 #' @examples
 #' if (interactive()) {
@@ -329,23 +333,18 @@ everywhere <- function(.expr, ..., .args = list(), .compute = "default") {
 #'
 #' @export
 #'
-call_mirai <- call_aio
+call_mirai <- call_aio_
 
-#' mirai (Call Value)
-#'
-#' \code{call_mirai_} is a variant of \code{call_mirai} that allows user
-#' interrupts, suitable for interactive use.
-#'
 #' @rdname call_mirai
 #' @export
 #'
-call_mirai_ <- call_aio_
+call_mirai_ <- call_mirai
 
 #' mirai (Collect Value)
 #'
 #' Waits for the \sQuote{mirai} to resolve if still in progress, and returns its
 #' value directly. It is a more efficient version of and equivalent to
-#' \code{call_mirai_(x)$data}.
+#' \code{call_mirai(x)$data}.
 #'
 #' This function will wait for the asynchronous operation(s) to complete if
 #' still in progress, blocking but interruptible.

--- a/man/call_mirai.Rd
+++ b/man/call_mirai.Rd
@@ -17,9 +17,8 @@ The passed object (invisibly). For a \sQuote{mirai}, the retrieved
   value is stored at \code{$data}.
 }
 \description{
-\code{call_mirai} waits for the \sQuote{mirai} to resolve if still in
-progress, storing the value at \code{$data}, and returns the \sQuote{mirai}
-object.
+Waits for the \sQuote{mirai} to resolve if still in progress, storing the
+value at \code{$data}, and returns the \sQuote{mirai} object.
 }
 \details{
 Accepts a list of \sQuote{mirai} objects, such as that returned by

--- a/man/call_mirai.Rd
+++ b/man/call_mirai.Rd
@@ -20,19 +20,20 @@ The passed object (invisibly). For a \sQuote{mirai}, the retrieved
 \code{call_mirai} waits for the \sQuote{mirai} to resolve if still in
 progress, storing the value at \code{$data}, and returns the \sQuote{mirai}
 object.
-
-\code{call_mirai_} is a variant of \code{call_mirai} that allows user
-interrupts, suitable for interactive use.
 }
 \details{
-Both functions accept a list of \sQuote{mirai} objects, such as that returned
-by \code{\link{mirai_map}} as well as individual \sQuote{mirai}.
+Accepts a list of \sQuote{mirai} objects, such as that returned by
+\code{\link{mirai_map}} as well as individual \sQuote{mirai}.
 
-They will wait for the asynchronous operation(s) to complete if still in
-progress (blocking).
+Waits for the asynchronous operation(s) to complete if still in progress,
+blocking but user-interruptible.
 
 \code{x[]} may also be used to wait for and return the value of a mirai
-\code{x}, and is the equivalent of \code{call_mirai_(x)$data}.
+\code{x}, and is the equivalent of \code{call_mirai(x)$data}.
+}
+\note{
+\code{call_mirai_} is deprecated and exported for historical compatibility
+only. It will be removed in a future package version.
 }
 \section{Alternatively}{
 

--- a/man/collect_mirai.Rd
+++ b/man/collect_mirai.Rd
@@ -21,7 +21,7 @@ An object (the return value of the \sQuote{mirai}), or a list of such
 \description{
 Waits for the \sQuote{mirai} to resolve if still in progress, and returns its
 value directly. It is a more efficient version of and equivalent to
-\code{call_mirai_(x)$data}.
+\code{call_mirai(x)$data}.
 }
 \details{
 This function will wait for the asynchronous operation(s) to complete if


### PR DESCRIPTION
Makes `call_mirai()` user-interruptible.
- Negates the needs for a separate awkwardly-named `call_mirai_()`

This completes the transition to entirely user-interruptible functions across the package.
- Follows decision to make `[` method interruptible by default when it was introduced in mirai 1.1.0.
- `collect_mirai()` made interruptible in mirai 2.0.0.

Since nanonext 1.3.1, all interruptible waits are performed by a long-lived dedicated thread hence the overhead vs. a blocking call is miniscule. For truly critical applications, the equivalent blocking functions may be used directly from nanonext.