### PR TITLE
mirai accepts an environment containing dot-variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * `call_mirai()` is now user-interruptible, consistent with all other functions in the package.
   + `call_mirai_()` is hence redundant and now deprecated.
+* Passing an environment to `mirai()` arguments `...` or `.args` now correctly includes any objects inside the environment beginning with `.` (#207).
   
 # mirai 2.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `call_mirai()` is now user-interruptible, consistent with all other functions in the package.
   + `call_mirai_()` is hence redundant and now deprecated.
-* Passing an environment to `mirai()` arguments `...` or `.args` now correctly includes any objects inside the environment beginning with `.` (#207).
+* `mirai()` arguments `...` and `.args` now accept environments containing variables beginning with a dot `.` (#207).
   
 # mirai 2.1.0
 

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -168,7 +168,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
     gn <- names(globals)
     if (is.null(gn)) {
       is.environment(globals[[1L]]) || stop(._[["named_dots"]])
-      globals <- as.list.environment(globals[[1L]])
+      globals <- as.list.environment(globals[[1L]], all.names = TRUE)
     }
     all(nzchar(gn)) || stop(._[["named_dots"]])
   }
@@ -178,7 +178,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
   )
   if (length(.args)) {
     if (is.environment(.args))
-      .args <- as.list.environment(.args) else
+      .args <- as.list.environment(.args, all.names = TRUE) else
         length(names(.args)) && all(nzchar(names(.args))) || stop(._[["named_args"]])
     data <- c(.args, data)
   }

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -50,10 +50,10 @@ for (i in 0:4)
 # mirai and daemons tests
 connection && {
   Sys.sleep(1L)
-  n <- function() m
+  .n <- function() m
   m <- mirai({
     Sys.sleep(0.1)
-    q <- m + n() + 2L
+    q <- m + .n() + 2L
     q / m
   }, m = 2L, .args = environment(), .timeout = 2000L)
   test_identical(call_mirai(m), m)


### PR DESCRIPTION
Fixes #207.

The conversion of the environment to a list using `as.list.environment()` must specify `all.names = TRUE`.