### PR TITLE
Fix `mirai()` accepting an environment containing dot-variables

### DIFF
--- a/R/mirai.R
+++ b/R/mirai.R
@@ -169,6 +169,8 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
     if (is.null(gn)) {
       is.environment(globals[[1L]]) || stop(._[["named_dots"]])
       globals <- as.list.environment(globals[[1L]], all.names = TRUE)
+      if (".Random.seed" %in% names(globals))
+        globals[[".Random.seed"]] <- NULL
     }
     all(nzchar(gn)) || stop(._[["named_dots"]])
   }

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -76,7 +76,7 @@ connection && {
   test_true(!is_mirai_interrupt(me))
   test_class("errorValue", me)
   test_print(me)
-  df <- data.frame(a = 1, b = 2)
+  df <- data.frame(a = 1, b = 2, .Random.seed = 0)
   dm <- mirai(as.matrix(df), .args = list(df = df), .timeout = 2000L)
   test_true(is_mirai(call_mirai(dm)))
   test_true(!unresolved(dm))


### PR DESCRIPTION
Special case `.Random.seed` when passing an environment to `...`

Really fixes #207.