### PR TITLE
Reverts `daemons()` error behaviour for revised settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mirai (development version)
 
+#### Behavioural Changes
+
+* `daemons()` providing revised settings for a compute profile, now warns and has no effect rather than error (amending the change made in mirai 2.1.0).
+  + This protects against errors when automated systems attempt to run a script multiple times in the same session.
+
 #### Updates
 
 * `call_mirai()` is now user-interruptible, consistent with all other functions in the package.

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -271,7 +271,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
       if (length(remote))
         launch_remote(n = n, remote = remote, tls = envir[["tls"]], ..., .compute = .compute)
     } else {
-      stop(sprintf(._[["daemons_set"]], .compute))
+      warning(sprintf(._[["daemons_set"]], .compute), immediate. = TRUE)
     }
 
   } else {
@@ -315,7 +315,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
       )
       `[[<-`(.., .compute, `[[<-`(`[[<-`(`[[<-`(envir, "sock", sock), "n", n), "dots", dots))
     } else {
-      stop(sprintf(._[["daemons_set"]], .compute))
+      warning(sprintf(._[["daemons_set"]], .compute), immediate. = TRUE)
     }
 
   }

--- a/R/mirai-package.R
+++ b/R/mirai-package.R
@@ -88,7 +88,7 @@
   list(
     arglen = "`n` must equal the length of `args`, or either must be 1",
     cluster_inactive = "cluster is no longer active",
-    daemons_set = "daemons already set for `%s` compute profile",
+    daemons_set = "this has no effect as daemons already set for `%s` compute profile",
     daemons_unset = "daemons must be set to use launchers",
     dispatcher_args = "`dispatcher` must be either TRUE or FALSE",
     dot_required = "`.` must be an element of the character vector(s) supplied to `args`",

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -67,7 +67,7 @@ connection && {
   Sys.sleep(1L)
   test_equal(1L, d <- daemons(1L, dispatcher = FALSE, asyncdial = FALSE, seed = 1546L))
   test_print(d)
-  test_error(daemons(1L), "daemons already set")
+  test_equal(1L, suppressWarnings(daemons(1L)))
   me <- mirai(mirai::mirai(), .timeout = 2000L)[]
   if (!is_mirai_error(me)) test_true(is_error_value(me))
   if (is_mirai_error(me)) test_type("list", me$stack.trace)
@@ -104,7 +104,7 @@ connection && {
   Sys.sleep(1L)
   test_type("integer", status(.compute = "new")[["connections"]])
   test_error(mirai_map(1:2, "a function", .compute = "new"), "must be of type function, not character")
-  test_error(daemons(url = local_url(), .compute = "new"), "daemons already set")
+  test_equal(1L, suppressWarnings(daemons(url = local_url(), .compute = "new")))
   test_zero(daemons(0L, .compute = "new"))
 }
 # additional daemons tests


### PR DESCRIPTION
Fixes #211.

Preserves explicit behaviour from #200 by issuing an immediate warning.

Otherwise retains behaviour prior to mirai 2.1.0 by revised settings (without a reset) having no effect.