### PR TITLE
Upgrades `with()` method to propagate `.compute`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
   + Directly use `parallel::makeCluster(type = "MIRAI")` to create a 'miraiCluster'.
 * `call_mirai()` is now user-interruptible, consistent with all other functions in the package.
   + `call_mirai_()` is hence redundant and now deprecated.
+* `with()` method for `daemons()` now propagates ".compute" so that this does not need to be specified in functions such as `mirai()` within the `with()` clause.
 * `mirai()` arguments `...` and `.args` now accept environments containing variables beginning with a dot `.` (#207).
 * 'miraiError' stack traces no longer sometimes contain an additional (internal) call (#216).
 * 'miraiError' condition `$call` objects are now stripped of 'srcref' attributes (thanks @lionel-, #218).

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -234,7 +234,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
 
   missing(n) && missing(url) && return(status(.compute))
 
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
 
   if (is.character(url)) {
 
@@ -416,7 +416,7 @@ with.miraiDaemons <- function(data, expr, ...) {
 status <- function(.compute = "default") {
 
   is.list(.compute) && return(status(attr(.compute, "id")))
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
   is.null(envir) && return(list(connections = 0L, daemons = 0L))
   length(envir[["msgid"]]) && return(dispatcher_status(envir))
   list(connections = as.integer(stat(envir[["sock"]], "pipes")), daemons = envir[["urls"]])

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -234,7 +234,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
 
   missing(n) && missing(url) && return(status(.compute))
 
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
 
   if (is.character(url)) {
 
@@ -361,7 +361,12 @@ print.miraiDaemons <- function(x, ...) print(unclass(x))
 #'
 with.miraiDaemons <- function(data, expr, ...) {
 
-  on.exit(daemons(0L, .compute = class(data)[2L]))
+  prev_profile <- .[["cp"]]
+  `[[<-`(., "cp", class(data)[2L])
+  on.exit({
+    daemons(0L)
+    `[[<-`(., "cp", prev_profile)
+  })
   expr
 
 }
@@ -411,7 +416,7 @@ with.miraiDaemons <- function(data, expr, ...) {
 status <- function(.compute = "default") {
 
   is.list(.compute) && return(status(attr(.compute, "id")))
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
   is.null(envir) && return(list(connections = 0L, daemons = 0L))
   length(envir[["msgid"]]) && return(dispatcher_status(envir))
   list(connections = as.integer(stat(envir[["sock"]], "pipes")), daemons = envir[["urls"]])

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -74,7 +74,7 @@
 #'
 launch_local <- function(n = 1L, ..., tls = NULL, .compute = "default") {
 
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
   is.null(envir) && stop(._[["daemons_unset"]])
   url <- envir[["urls"]]
   write_args <- if (length(envir[["msgid"]])) wa3 else wa2
@@ -113,7 +113,7 @@ launch_remote <- function(n = 1L, remote = remote_config(), ..., tls = NULL, .co
     n <- max(length(n), 1L)
   }
   n <- as.integer(n)
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
   is.null(envir) && stop(._[["daemons_unset"]])
   url <- envir[["urls"]]
   write_args <- if (length(envir[["msgid"]])) wa3 else wa2

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -74,7 +74,7 @@
 #'
 launch_local <- function(n = 1L, ..., tls = NULL, .compute = "default") {
 
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
   is.null(envir) && stop(._[["daemons_unset"]])
   url <- envir[["urls"]]
   write_args <- if (length(envir[["msgid"]])) wa3 else wa2
@@ -113,7 +113,7 @@ launch_remote <- function(n = 1L, remote = remote_config(), ..., tls = NULL, .co
     n <- max(length(n), 1L)
   }
   n <- as.integer(n)
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
   is.null(envir) && stop(._[["daemons_unset"]])
   url <- envir[["urls"]]
   write_args <- if (length(envir[["msgid"]])) wa3 else wa2

--- a/R/map.R
+++ b/R/map.R
@@ -164,7 +164,7 @@
 #'
 mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "default") {
 
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
   is.null(envir) && stop(._[["requires_daemons"]])
   is.function(.f) || stop(sprintf(._[["function_required"]], typeof(.f)))
 

--- a/R/map.R
+++ b/R/map.R
@@ -164,7 +164,7 @@
 #'
 mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = "default") {
 
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
   is.null(envir) && stop(._[["requires_daemons"]])
   is.function(.f) || stop(sprintf(._[["function_required"]], typeof(.f)))
 

--- a/R/mirai-package.R
+++ b/R/mirai-package.R
@@ -79,7 +79,7 @@
 
 # nocov end
 
-. <- new.env()
+. <- `[[<-`(new.env(), "cp", "default")
 .. <- new.env()
 .command <- NULL
 .urlscheme <- NULL

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -180,7 +180,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
     data <- c(.args, data)
   }
 
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
   is.null(envir) && return(ephemeral_daemon(data, .timeout))
   r <- request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]])
   `attr<-`(`attr<-`(r, "msgid", next_msgid(envir)), "profile", .compute)
@@ -241,7 +241,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
 #'
 everywhere <- function(.expr, ..., .args = list(), .compute = "default") {
 
-  envir <- ..[[.compute]]
+  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
 
   is.null(envir) && stop(sprintf(._[["not_found"]], .compute))
 

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -180,7 +180,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
     data <- c(.args, data)
   }
 
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
   is.null(envir) && return(ephemeral_daemon(data, .timeout))
   r <- request(.context(envir[["sock"]]), data, send_mode = 1L, recv_mode = 1L, timeout = .timeout, cv = envir[["cv"]])
   `attr<-`(`attr<-`(r, "msgid", next_msgid(envir)), "profile", .compute)
@@ -241,7 +241,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = "defau
 #'
 everywhere <- function(.expr, ..., .args = list(), .compute = "default") {
 
-  envir <- if (missing(.compute)) ..[[.subset2(., "cp")]] else ..[[.compute]]
+  envir <- ..[[if (missing(.compute)) .[["cp"]] else .compute]]
 
   is.null(envir) && stop(sprintf(._[["not_found"]], .compute))
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -127,8 +127,8 @@ connection && {
 connection && {
   Sys.sleep(1L)
   m <- with(daemons(1, dispatcher = FALSE, .compute = "ml"), {
-    if (is.null(tryCatch(mirai_map(list(1, "a", 2), sum, .compute = "ml")[.stop], error = function(e) NULL)))
-      mirai_map(1:3, rnorm, .args = list(mean = 20, 2), .compute = "ml")[]
+    if (is.null(tryCatch(mirai_map(list(1, "a", 2), sum)[.stop], error = function(e) NULL)))
+      mirai_map(1:3, rnorm, .args = list(mean = 20, 2))[]
   })
   test_true(!is_mirai_map(m))
   test_type("list", m)


### PR DESCRIPTION
Try to preserve existing behaviour with the compute profile as the character string `"default"`. This is in the end no different to using a `current_profile()` getter function or some sentinel such as `NULL`.

Solution employed is to use one layer of indirection if the `.compute` argument is missing. Functions which set a temporary state, such as the `with()` method for `daemons()`, set what `"default"` actually directs to.

Lays the groundwork for an implementation of `with_daemons()` / `local_daemons()` or `with_profile()` / `local_profile()` - some further thought needs to go into the naming.