### PR TITLE
Continuity for daemons() error behaviour introduced in mirai 2.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mirai
 Type: Package
 Title: Minimalist Async Evaluation Framework for R
-Version: 2.1.0.9000
+Version: 2.1.0.9001
 Description: Designed for simplicity, a 'mirai' evaluates an R expression
     asynchronously in a parallel process, locally or distributed over the
     network. The result is automatically available upon completion. Modern

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
 # mirai (development version)
 
-#### Behavioural Changes
+#### New Features
 
 * Simplifies SSH tunnelling for distributed computing:
-  + `ssh_config()` argument 'port' is removed, with the tunnel port now inferred at the time of launch, and is no longer set by the configuration.
+  + `ssh_config()` argument 'port' is removed, with the tunnel port now inferred at the time of launch, and no longer set by the configuration.
   + `local_url()` adds logical argument 'tcp' for easily constructing an automatic local TCP URL when setting `daemons()` for SSH tunnelling.
 
 #### Updates

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,6 @@
 * Simplifies SSH tunnelling for distributed computing:
   + `ssh_config()` argument 'port' is removed, with the tunnel port now inferred at the time of launch, and is no longer set by the configuration.
   + `local_url()` adds logical argument 'tcp' for easily constructing an automatic local TCP URL when setting `daemons()` for SSH tunnelling.
-* `daemons()` providing revised settings for a compute profile, now warns and has no effect rather than error (amending the change made in mirai 2.1.0).
-  + This protects against errors when automated systems attempt to run a script multiple times in the same session.
 
 #### Updates
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,8 @@
 
 #### Updates
 
-* Removes `register_cluster()` added in v0.13.2.
-  + mirai (in R >= 4.5) is now one of the official base R parallel cluster types, and registration is no longer required.
+* mirai (in R >= 4.5) is now one of the official base R parallel cluster types, and `register_cluster()` is no longer required.
+  + Removes `register_cluster()` added in v0.13.2.
   + Directly use `parallel::makeCluster(type = "MIRAI")` to create a 'miraiCluster'.
 * `call_mirai()` is now user-interruptible, consistent with all other functions in the package.
   + `call_mirai_()` is hence redundant and now deprecated.

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -267,7 +267,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
       if (length(remote))
         launch_remote(n = n, remote = remote, tls = envir[["tls"]], ..., .compute = .compute)
     } else {
-      warning(sprintf(._[["daemons_set"]], .compute), immediate. = TRUE)
+      stop(sprintf(._[["daemons_set"]], .compute))
     }
 
   } else {
@@ -311,7 +311,7 @@ daemons <- function(n, url = NULL, remote = NULL, dispatcher = TRUE, ...,
       )
       `[[<-`(.., .compute, `[[<-`(`[[<-`(`[[<-`(envir, "sock", sock), "n", n), "dots", dots))
     } else {
-      warning(sprintf(._[["daemons_set"]], .compute), immediate. = TRUE)
+      stop(sprintf(._[["daemons_set"]], .compute))
     }
 
   }

--- a/R/launchers.R
+++ b/R/launchers.R
@@ -252,6 +252,7 @@ remote_config <- function(command = NULL, args = c("", "."), rscript = "Rscript"
 #'   \sQuote{SSH Tunnelling} section below for further details.
 #' @param timeout \[default 10\] maximum time allowed for connection setup in
 #'   seconds.
+#' @param ... unused.
 #'
 #' @section SSH Direct Connections:
 #'
@@ -313,7 +314,7 @@ remote_config <- function(command = NULL, args = c("", "."), rscript = "Rscript"
 #' @rdname remote_config
 #' @export
 #'
-ssh_config <- function(remotes, tunnel = TRUE, timeout = 10, command = "ssh", rscript = "Rscript") {
+ssh_config <- function(remotes, tunnel = TRUE, timeout = 10, command = "ssh", rscript = "Rscript", ...) {
 
   premotes <- lapply(remotes, parse_url)
   hostnames <- lapply(premotes, .subset2, "hostname")

--- a/R/mirai-package.R
+++ b/R/mirai-package.R
@@ -88,7 +88,7 @@
   list(
     arglen = "`n` must equal the length of `args`, or either must be 1",
     cluster_inactive = "cluster is no longer active",
-    daemons_set = "ignored as daemons already set for `%s`",
+    daemons_set = "daemons already set for `%s` compute profile",
     daemons_unset = "daemons must be set to use launchers",
     dispatcher_args = "`dispatcher` should be either TRUE or FALSE",
     dot_required = "`.` must be an element of the character vector(s) supplied to `args`",

--- a/man/remote_config.Rd
+++ b/man/remote_config.Rd
@@ -17,7 +17,8 @@ ssh_config(
   tunnel = TRUE,
   timeout = 10,
   command = "ssh",
-  rscript = "Rscript"
+  rscript = "Rscript",
+  ...
 )
 }
 \arguments{
@@ -52,6 +53,8 @@ If TRUE, requires the \code{\link[=daemons]{daemons()}} \code{url} hostname to b
 
 \item{timeout}{[default 10] maximum time allowed for connection setup in
 seconds.}
+
+\item{...}{unused.}
 }
 \value{
 A list in the required format to be supplied to the \code{remote} argument

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -69,7 +69,7 @@ connection && {
   Sys.sleep(1L)
   test_equal(1L, d <- daemons(1L, dispatcher = FALSE, asyncdial = FALSE, seed = 1546L))
   test_print(d)
-  test_equal(1L, suppressWarnings(daemons(1L)))
+  test_error(daemons(1L), "daemons already set")
   me <- mirai(mirai::mirai(), .timeout = 2000L)[]
   if (!is_mirai_error(me)) test_true(is_error_value(me))
   if (is_mirai_error(me)) test_type("list", me$stack.trace)
@@ -106,7 +106,7 @@ connection && {
   Sys.sleep(1L)
   test_type("integer", status(.compute = "new")[["connections"]])
   test_error(mirai_map(1:2, "a function", .compute = "new"), "must be of type function, not character")
-  test_equal(1L, suppressWarnings(daemons(url = local_url(), .compute = "new")))
+  test_error(daemons(url = local_url(), .compute = "new"), "daemons already set")
   test_zero(daemons(0L, .compute = "new"))
 }
 # additional daemons tests


### PR DESCRIPTION
Closes #211.