### PR TITLE
More efficient promises and parallel methods

### DIFF
--- a/R/parallel.R
+++ b/R/parallel.R
@@ -157,7 +157,7 @@ sendData.miraiNode <- function(node, data) {
   if (tagged) set_cv(envir) else unset_cv(envir)
 
   m <- mirai(do.call(node, data, quote = TRUE), node = value[["fun"]], data = value[["args"]], .compute = id)
-  if (tagged) assign("tag", value[["tag"]], envir = m)
+  if (tagged) `[[<-`(m, "tag", value[["tag"]])
   `[[<-`(node, "mirai", m)
 
 }

--- a/R/promises.R
+++ b/R/promises.R
@@ -87,7 +87,7 @@ as.promise.mirai <- function(x) {
       )
     }
 
-    assign("promise", promise, envir = x)
+    `[[<-`(x, "promise", promise)
 
   }
 


### PR DESCRIPTION
nanonext >= 1.5.2 will allow the use of `[[<-`.