### PR TITLE
Fix promise creation for already resolved mirai

### DIFF
--- a/R/promises.R
+++ b/R/promises.R
@@ -77,9 +77,11 @@ as.promise.mirai <- function(x) {
       value <- .subset2(x, "value")
       promises::promise(
         function(resolve, reject)
-          if (is_error_value(value) && !is_mirai_interrupt(value))
-            reject(value) else
-              resolve(value)
+          resolve(
+            if (is_error_value(value) && !is_mirai_interrupt(value))
+              stop(if (is_mirai_error(value)) value else nng_error(value)) else
+                value
+          )
       )
     }
 


### PR DESCRIPTION
Fixes #229. Ensures consistency whether a mirai is resolved or not.