### PR TITLE
Fix for stop_mirai() interrupts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Encoding: UTF-8
 Depends: 
     R (>= 3.6)
 Imports: 
-    nanonext (>= 1.5.2)
+    nanonext (>= 1.5.2.9000)
 Enhances: 
     parallel,
     promises
@@ -44,3 +44,4 @@ Suggests:
 VignetteBuilder: litedown
 RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
+Remotes: shikokuchuo/nanonext

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # mirai (development version)
 
+#### Updates
+
+* Fixes `stop_mirai()` failing to interrupt in certain cases on non-Windows platforms (thanks @LennardLux, #240).
+* Requires nanonext >= [1.5.2.9000].
+
 # mirai 2.2.0
 
 #### Behavioural Changes

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -394,7 +394,7 @@ collect_mirai <- function(x, options = NULL) {
 #'
 stop_mirai <- function(x) {
 
-  is.list(x) && return(invisible(as.logical(lapply(length(x):1, function(i) stop_mirai(.subset2(x, i))))))
+  is.list(x) && return(invisible(rev(as.logical(lapply(rev(unclass(x)), stop_mirai)))))
 
   .compute <- attr(x, "profile")
   envir <- if (is.character(.compute)) ..[[.compute]]

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -343,6 +343,7 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_equal(m1$data, 20L)
   test_class("errorValue", mirai(res)[])
   m <- mirai_map(1:10, function(x) { Sys.sleep(2); y <<- TRUE })
+  Sys.sleep(0.1)
   s <- stop_mirai(m)
   test_equal(sum(unlist(m[])), 200L)
   test_class("errorValue", mirai(y)[])

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -343,7 +343,6 @@ connection && Sys.getenv("NOT_CRAN") == "true" && {
   test_equal(m1$data, 20L)
   test_class("errorValue", mirai(res)[])
   m <- mirai_map(1:10, function(x) { Sys.sleep(2); y <<- TRUE })
-  Sys.sleep(0.1)
   s <- stop_mirai(m)
   test_equal(sum(unlist(m[])), 200L)
   test_class("errorValue", mirai(y)[])


### PR DESCRIPTION
See #240. Closes shikokuchuo/nanonext#97.