### PR TITLE
Global L'Ecuyer RNG stream for reproducible results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # mirai (development version)
 
+#### Behavioural Changes
+
+* The `seed` argument of `daemons()` now changes the default random seed behaviour.
+  The default uses L'Ecuyer-CMRG RNG streams advanced per daemon, which produces statistically-sound yet generally non-reproducible results.
+  Setting a seed now initialises a global L'Ecuyer-CMRG RNG stream, which is advanced for each mirai evaluation, and hence does provide reproducible results.
+
 #### Updates
 
 * Fixes a bug where using non-dispatcher daemons, an `unresolvedValue` would rarely (and non-deterministically) be returned as the fulfilled value of a promise (thanks @James-G-Hill and @olivier7121, #243 and #317).

--- a/R/daemons.R
+++ b/R/daemons.R
@@ -50,13 +50,16 @@
 #' @param ... (optional) additional arguments passed through to
 #'   [daemon()] if launching daemons. These include `asyncdial`, `autoexit`,
 #'   `cleanup`, `output`, `maxtasks`, `idletime` and `walltime`.
-#' @param seed \[default NULL\] (optional) supply a random seed (single value,
-#'   interpreted as an integer). This is used to inititalise the L'Ecuyer-CMRG
-#'   RNG streams sent to each daemon. Note that reproducible results can be
-#'   expected only for `dispatcher = FALSE`, as the unpredictable timing of task
-#'   completions would otherwise influence the tasks sent to each daemon. Even
-#'   for `dispatcher = FALSE`, reproducibility is not guaranteed if the order in
-#'   which tasks are sent is not deterministic.
+#' @param seed \[default NULL\] (optional) For the default of NULL, this
+#'   inititalises L'Ecuyer-CMRG RNG streams for each daemon. Results are
+#'   statistically-sound, although generally non-reproducible. This is as (i)
+#'   which tasks are sent to which daemon is non-deterministic using dispatcher
+#'   and (ii) also depends on the number of daemons actually connected etc.\cr
+#'   (experimental) instead, supplying a random seed (single integer value)
+#'   changes the default behaviour by inititalising a global L'Ecuyer-CMRG RNG
+#'   stream on host. This is advanced for each mirai evaluation (rather than
+#'   once for each daemon). This now allows for reproducible results independent
+#'   of where the mirai is evaluated, as the random seed travels with it.
 #' @param serial \[default NULL\] (optional, requires dispatcher) a
 #'   configuration created by [serial_config()] to register serialization and
 #'   unserialization functions for normally non-exportable reference objects,
@@ -545,6 +548,7 @@ init_envir_stream <- function(seed) {
     "stream",
     .GlobalEnv[[".Random.seed"]]
   )
+  `[[<-`(envir, "seed", seed)
   `[[<-`(.GlobalEnv, ".Random.seed", oseed)
   envir
 }

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -146,6 +146,8 @@ mirai <- function(
   .compute = NULL
 ) {
   missing(.expr) && stop(._[["missing_expression"]])
+  if (is.null(.compute)) .compute <- .[["cp"]]
+  envir <- ..[[.compute]]
 
   expr <- substitute(.expr)
   globals <- list(...)
@@ -159,6 +161,8 @@ mirai <- function(
       }
       all(nzchar(gn)) || stop(._[["named_dots"]])
     }
+  if (length(envir[["seed"]]))
+    globals[[".Random.seed"]] <- next_stream(envir)
   data <- list(
     ._mirai_globals_. = globals,
     .expr = if (
@@ -175,8 +179,6 @@ mirai <- function(
     data <- c(.args, data)
   }
 
-  if (is.null(.compute)) .compute <- .[["cp"]]
-  envir <- ..[[.compute]]
   is.null(envir) && return(ephemeral_daemon(data, .timeout))
 
   request(

--- a/man/daemons.Rd
+++ b/man/daemons.Rd
@@ -38,13 +38,16 @@ and should normally be kept on (for details see Dispatcher section below).}
 \code{\link[=daemon]{daemon()}} if launching daemons. These include \code{asyncdial}, \code{autoexit},
 \code{cleanup}, \code{output}, \code{maxtasks}, \code{idletime} and \code{walltime}.}
 
-\item{seed}{[default NULL] (optional) supply a random seed (single value,
-interpreted as an integer). This is used to inititalise the L'Ecuyer-CMRG
-RNG streams sent to each daemon. Note that reproducible results can be
-expected only for \code{dispatcher = FALSE}, as the unpredictable timing of task
-completions would otherwise influence the tasks sent to each daemon. Even
-for \code{dispatcher = FALSE}, reproducibility is not guaranteed if the order in
-which tasks are sent is not deterministic.}
+\item{seed}{[default NULL] (optional) For the default of NULL, this
+inititalises L'Ecuyer-CMRG RNG streams for each daemon. Results are
+statistically-sound, although generally non-reproducible. This is as (i)
+which tasks are sent to which daemon is non-deterministic using dispatcher
+and (ii) also depends on the number of daemons actually connected etc.\cr
+(experimental) instead, supplying a random seed (single integer value)
+changes the default behaviour by inititalising a global L'Ecuyer-CMRG RNG
+stream on host. This is advanced for each mirai evaluation (rather than
+once for each daemon). This now allows for reproducible results independent
+of where the mirai is evaluated, as the random seed travels with it.}
 
 \item{serial}{[default NULL] (optional, requires dispatcher) a
 configuration created by \code{\link[=serial_config]{serial_config()}} to register serialization and


### PR DESCRIPTION
Closes #290.

This solution implements a global L'Ecuyer-CMRG RNG stream, which is advanced per `mirai()` call, travels with the mirai, and set in the global environment of the daemon prior to evaluation.

Opt-in by supplying an integer seed to `daemons(seed=)`.