### PR TITLE
Ensure silent background execution

### DIFF
--- a/R/daemon.R
+++ b/R/daemon.R
@@ -110,14 +110,6 @@ daemon <- function(
     devnull <- file(nullfile(), open = "w", blocking = FALSE)
     sink(file = devnull)
     sink(file = devnull, type = "message")
-    on.exit(
-      {
-        sink(type = "message")
-        sink()
-        close(devnull)
-      },
-      add = TRUE
-    )
   }
   xc <- 0L
   task <- 1L


### PR DESCRIPTION
Follow up to #349 and completes solution in #350.

Prevents `Execution halted` being shown when daemons crash or e.g. upon:
```r
library(mirai)
daemons(1, autoexit = FALSE)
daemons(NULL)
```