### PR TITLE
Add "Supported By Posit" badge to mirai website

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -5,6 +5,7 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-hide-below="1200" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="mirai.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
     after_navbar: |
       <a href="https://deepwiki.com/r-lib/mirai"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
@@ -15,10 +16,10 @@ reference:
 development:
   mode: auto
 news:
- releases:
- - text: "mirai 2.5.0"
-   href: https://www.tidyverse.org/blog/2025/09/mirai-2-5-0/
- - text: "mirai 2.4.0"
-   href: https://shikokuchuo.net/posts/27-mirai-240/
- - text: "mirai 2.3.0"
-   href: https://shikokuchuo.net/posts/26-mirai-230/
+  releases:
+  - text: "mirai 2.5.0"
+    href: https://www.tidyverse.org/blog/2025/09/mirai-2-5-0/
+  - text: "mirai 2.4.0"
+    href: https://shikokuchuo.net/posts/27-mirai-240/
+  - text: "mirai 2.3.0"
+    href: https://shikokuchuo.net/posts/26-mirai-230/


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the mirai website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of mirai website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/mirai-1200.png)

At 992px browser width:

![Screenshot of mirai website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/mirai-992.png)

At 991px browser width:

![Screenshot of mirai website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/mirai-991.png)

