### PR TITLE
Update package authors vignette for `mirai_map()` sync fallback

### DIFF
--- a/dev/vignettes/_v06-packages.Rmd
+++ b/dev/vignettes/_v06-packages.Rmd
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 mirai offers the following functions primarily for package authors using mirai:
 
 1. `require_daemons()` will error and prompt the user to set daemons (with a clickable function link if the cli package is available) if daemons are not already set.
-1. `daemons_set()`, to detect if daemons have already been set and prompt the user to set daemons if not.
+1. `daemons_set()`, to detect if daemons have already been set.
 1. `on_daemon()`, to detect if code is already running on a daemon, i.e. within a `mirai()` call.
 1. `register_serial()` to register custom serialization functions, which are automatically available by default for all subsequent `daemons()` calls.
 1. `nextget()`, for querying values for a compute profile, such as 'url', described in the function's documentation. Note: only the specifically-documented values are supported interfaces.

--- a/vignettes/v06-packages.Rmd
+++ b/vignettes/v06-packages.Rmd
@@ -13,7 +13,7 @@ vignette: >
 mirai offers the following functions primarily for package authors using mirai:
 
 1. `require_daemons()` will error and prompt the user to set daemons (with a clickable function link if the cli package is available) if daemons are not already set.
-1. `daemons_set()`, to detect if daemons have already been set and prompt the user to set daemons if not.
+1. `daemons_set()`, to detect if daemons have already been set.
 1. `on_daemon()`, to detect if code is already running on a daemon, i.e. within a `mirai()` call.
 1. `register_serial()` to register custom serialization functions, which are automatically available by default for all subsequent `daemons()` calls.
 1. `nextget()`, for querying values for a compute profile, such as 'url', described in the function's documentation. Note: only the specifically-documented values are supported interfaces.


### PR DESCRIPTION
Closes #487.