### PR TITLE
Optimize otel implementation for performance

### DIFF
--- a/R/daemons.R
+++ b/R/daemons.R
@@ -283,11 +283,7 @@ daemons <- function(
 
       if (signal) send_signal(envir)
       reap(envir[["sock"]])
-      otel_active_span(
-        sprintf("daemons reset %s", envir[["url"]]),
-        attributes = otel_daemons_attrs(envir),
-        links = if (length(envir[["otel_span"]])) list(envir[["otel_span"]])
-      )
+      otel_span("daemons reset", envir[["url"]], otel_attrs(envir), links = list(envir[["otel_span"]]))
       ..[[.compute]] <- NULL -> envir
       msleep(.sleep_daemons)
       return(invisible(FALSE))
@@ -323,10 +319,7 @@ daemons <- function(
     )
   })
 
-  `[[<-`(envir, "otel_span", otel_active_span(
-    sprintf("daemons set %s", envir[["url"]]),
-    attributes = otel_daemons_attrs(envir)
-  ))
+  `[[<-`(envir, "otel_span", otel_span("daemons set", envir[["url"]], otel_attrs(envir)))
 
   invisible(`class<-`(TRUE, c("miraiDaemons", .compute)))
 }

--- a/R/map.R
+++ b/R/map.R
@@ -158,11 +158,7 @@ mirai_map <- function(.x, .f, ..., .args = list(), .promise = NULL, .compute = N
   is.function(.f) || stop(sprintf(._[["function_required"]], typeof(.f)))
   if (is.null(.compute)) .compute <- .[["cp"]]
 
-  spn <- otel_active_span(
-    "mirai_map",
-    links = list(..[[.compute]][["otel_span"]]),
-    scope = environment()
-  )
+  spn <- otel_map_span(.compute)
 
   dx <- dim(.x)
   vec <- if (is.null(dx)) {

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -155,14 +155,7 @@ mirai <- function(.expr, ..., .args = list(), .timeout = NULL, .compute = NULL) 
     }
     all(nzchar(gn)) || stop(._[["named_dots"]])
   }
-  ctx_spn <- otel_active_span(
-    "mirai",
-    cond = length(envir),
-    links = list(envir[["otel_span"]]),
-    options = list(kind = "client"),
-    return_ctx = TRUE,
-    scope = environment()
-  )
+  ctx_spn <- otel_mirai_span(envir)
   if (length(envir[["seed"]])) globals[[".Random.seed"]] <- next_stream(envir)
   data <- list(
     ._expr_. = if (


### PR DESCRIPTION
- Breaks up the generic otel helper into several special helpers
- Side-benefit is that all the otel logic is consolidated in `otel.R`, with less verbosity in the rest of the codebase