### PR TITLE
Fix `everywhere()` sync point logic

### DIFF
--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -192,14 +192,14 @@ dispatcher <- function(host, url = NULL, n = 0L, ...) {
               if (is_marked) {
                 item[["sync"]] && next
                 `[[<-`(item, "sync", TRUE)
+              } else {
+                item[["sync"]] && next
+                lapply(outq, `[[<-`, "sync", FALSE)
               }
               send(psock, inq[[1L]][["req"]], mode = 2L, pipe = item[["pipe"]], block = TRUE)
               `[[<-`(item, "ctx", inq[[1L]][["ctx"]])
               `[[<-`(item, "msgid", inq[[1L]][["msgid"]])
               inq[[1L]] <- NULL
-              if (is_marked && (!length(inq) || !.read_marker(inq[[1L]][["req"]]))) {
-                lapply(outq, `[[<-`, "sync", FALSE)
-              }
               break
             }
         }

--- a/R/mirai.R
+++ b/R/mirai.R
@@ -284,9 +284,13 @@ everywhere <- function(.expr, ..., .args = list(), .min = 1L, .compute = NULL) {
   seed <- envir[["seed"]]
   on.exit(`[[<-`(envir, "seed", seed))
   `[[<-`(envir, "seed", NULL)
-  vec <- marked(lapply(seq_len(xlen), function(i) {
-    mirai(.expr, ..., .args = .args, .compute = .compute)
-  }))
+  vec <- lapply(seq_len(xlen), function(i) {
+    if (i < xlen) {
+      marked(mirai(.expr, ..., .args = .args, .compute = .compute))
+    } else {
+      mirai(.expr, ..., .args = .args, .compute = .compute)
+    }
+  })
   `[[<-`(envir, "everywhere", vec)
   invisible(`class<-`(vec, "mirai_map"))
 }


### PR DESCRIPTION
Fixes indeterminacy introduced by #525. Reverts to use of an unmarked mirai to clear the sync point - but using the final mirai rather than a new barrier mirai.
 - This also handles the single mirai case as those will simply be unmarked.