### PR TITLE
Simplify `.libPaths()` for dispatcher

### DIFF
--- a/R/daemons.R
+++ b/R/daemons.R
@@ -674,7 +674,7 @@ args_daemon_disp <- function(url, dots, rs = NULL, tls = NULL) {
 
 args_dispatcher <- function(urld, url, n) {
   shQuote(sprintf(
-    ".libPaths(c(\"%s\",.libPaths()));mirai::dispatcher(\"%s\",url=\"%s\",n=%d)",
+    ".libPaths(\"%s\");mirai::dispatcher(\"%s\",url=\"%s\",n=%d)",
     libp(),
     urld,
     url,


### PR DESCRIPTION
Discovered following work on the new HTTP launcher.

For dispatcher, that is only ever going to run the mirai/nanonext dispatcher loop so we only need the single library path that contains mirai.