### PR TITLE
Use listener URL attribute directly

### DIFF
--- a/R/daemons.R
+++ b/R/daemons.R
@@ -755,24 +755,10 @@ launch_daemons <- function(seq, dots, envir) {
   pipe_notify(sock, NULL, add = TRUE)
 }
 
-sub_real_port <- function(sock, url) {
-  if (parse_url(url)[["port"]] == "0") {
-    url <- sub(
-      "(?<=:)0(?![^/])",
-      opt(attr(sock, "listener")[[1L]], "tcp-bound-port"),
-      url,
-      perl = TRUE
-    )
-  }
-  url
-}
-
 create_sock <- function(envir, url, tls) {
   sock <- req_socket(url, tls = tls)
-  url <- sub_real_port(sock, url)
-  `[[<-`(envir, "cv", cv())
   `[[<-`(envir, "sock", sock)
-  `[[<-`(envir, "url", url)
+  `[[<-`(envir, "url", attr(attr(sock, "listener")[[1L]], "url"))
 }
 
 send_signal <- function(envir) {

--- a/R/dispatcher.R
+++ b/R/dispatcher.R
@@ -67,7 +67,7 @@ dispatcher <- function(host, url = NULL, n = 0L) {
     }
   } else {
     listen(psock, url = url, tls = tls, fail = 2L)
-    url <- sub_real_port(psock, url)
+    url <- attr(attr(psock, "listener")[[1L]], "url")
   }
   send(sock, url, mode = 2L, block = TRUE)
 


### PR DESCRIPTION
As nanonext now updates a `0` port to the actual OS-assigned port.